### PR TITLE
Expose additional Adlar heat pump sensors

### DIFF
--- a/.homeycompose/capabilities/measure_ambient_temperature.json
+++ b/.homeycompose/capabilities/measure_ambient_temperature.json
@@ -1,0 +1,13 @@
+{
+  "type": "number",
+  "title": {
+    "en": "Ambient Temperature"
+  },
+  "units": {
+    "en": "°C"
+  },
+  "decimals": 1,
+  "getable": true,
+  "setable": false,
+  "uiComponent": "sensor"
+}

--- a/.homeycompose/capabilities/measure_water_flow.json
+++ b/.homeycompose/capabilities/measure_water_flow.json
@@ -1,0 +1,13 @@
+{
+  "type": "number",
+  "title": {
+    "en": "Water Flow"
+  },
+  "units": {
+    "en": "L/min"
+  },
+  "decimals": 1,
+  "getable": true,
+  "setable": false,
+  "uiComponent": "sensor"
+}

--- a/.homeycompose/capabilities/measure_water_temperature_out.json
+++ b/.homeycompose/capabilities/measure_water_temperature_out.json
@@ -1,0 +1,13 @@
+{
+  "type": "number",
+  "title": {
+    "en": "Water Temperature Out"
+  },
+  "units": {
+    "en": "°C"
+  },
+  "decimals": 1,
+  "getable": true,
+  "setable": false,
+  "uiComponent": "sensor"
+}

--- a/.homeycompose/drivers/adlar_heat_pump/driver.compose.json
+++ b/.homeycompose/drivers/adlar_heat_pump/driver.compose.json
@@ -7,6 +7,12 @@
   "capabilities": [
     "onoff",
     "target_temperature",
-    "measure_temperature"
+    "measure_temperature",
+    "measure_water_temperature_out",
+    "measure_ambient_temperature",
+    "measure_water_flow",
+    "measure_current",
+    "measure_voltage",
+    "measure_power"
   ]
 }

--- a/drivers/adlar_heat_pump/device.js
+++ b/drivers/adlar_heat_pump/device.js
@@ -22,8 +22,20 @@ class AdlarHeatPumpDevice extends Device {
 
   async updateStatus() {
     try {
-      const temp = await this.tuya.get({ dps: 3 });
-      this.setCapabilityValue('measure_temperature', Number(temp));
+      const tempIn = await this.tuya.get({ dps: 3 });
+      this.setCapabilityValue('measure_temperature', Number(tempIn));
+      const tempOut = await this.tuya.get({ dps: 4 });
+      this.setCapabilityValue('measure_water_temperature_out', Number(tempOut));
+      const ambient = await this.tuya.get({ dps: 6 });
+      this.setCapabilityValue('measure_ambient_temperature', Number(ambient));
+      const flow = await this.tuya.get({ dps: 26 });
+      this.setCapabilityValue('measure_water_flow', Number(flow));
+      const current = await this.tuya.get({ dps: 102 });
+      this.setCapabilityValue('measure_current', Number(current) * 0.001);
+      const voltage = await this.tuya.get({ dps: 103 });
+      this.setCapabilityValue('measure_voltage', Number(voltage));
+      const power = await this.tuya.get({ dps: 104 });
+      this.setCapabilityValue('measure_power', Number(power) * 0.1);
       const target = await this.tuya.get({ dps: 2 });
       this.setCapabilityValue('target_temperature', Number(target));
     } catch (error) {

--- a/drivers/adlar_heat_pump/driver.json
+++ b/drivers/adlar_heat_pump/driver.json
@@ -7,6 +7,12 @@
   "capabilities": [
     "onoff",
     "target_temperature",
-    "measure_temperature"
+    "measure_temperature",
+    "measure_water_temperature_out",
+    "measure_ambient_temperature",
+    "measure_water_flow",
+    "measure_current",
+    "measure_voltage",
+    "measure_power"
   ]
 }


### PR DESCRIPTION
## Summary
- add driver capabilities for water outlet and ambient temperatures plus electrical metrics
- poll DPS 3,4,6,26,102,103 and 104 to update the Homey capabilities
- expose water flow rate via new `measure_water_flow` capability

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d8f93d6c8330acb7623bbbd4be23