### PR TITLE
Add device discovery to Homey pair flow

### DIFF
--- a/drivers/adlar_heat_pump/driver.js
+++ b/drivers/adlar_heat_pump/driver.js
@@ -9,7 +9,7 @@ class AdlarHeatPumpDriver extends Driver {
     this.log('Adlar Heat Pump driver has been initialized');
   }
 
-  async onPairListDevices() {
+  async _discoverAndMerge() {
     const found = await discoverDevices();
     let cloud = [];
     const username = process.env.TUYA_USERNAME;
@@ -31,6 +31,16 @@ class AdlarHeatPumpDriver extends Driver {
         data: { id: dev.id },
         settings: { ip: dev.ip, key: info.key || '' }
       };
+    });
+  }
+
+  async onPairListDevices() {
+    return this._discoverAndMerge();
+  }
+
+  async onPair(session) {
+    session.setHandler('discover', async () => {
+      return this._discoverAndMerge();
     });
   }
 }

--- a/drivers/adlar_heat_pump/pair/start.html
+++ b/drivers/adlar_heat_pump/pair/start.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <script src="/homey.js" data-origin="local"></script>
+  </head>
+  <body>
+    <p>Searching for Adlar Heat Pumps...</p>
+    <ul id="devices"></ul>
+    <script src="start.js"></script>
+  </body>
+</html>

--- a/drivers/adlar_heat_pump/pair/start.js
+++ b/drivers/adlar_heat_pump/pair/start.js
@@ -1,0 +1,22 @@
+Homey.on('init', async () => {
+  const listEl = document.getElementById('devices');
+  try {
+    const devices = await Homey.emit('discover');
+    if (devices.length === 0) {
+      const li = document.createElement('li');
+      li.textContent = 'No devices found';
+      listEl.appendChild(li);
+      return;
+    }
+    devices.forEach(device => {
+      const li = document.createElement('li');
+      const btn = document.createElement('button');
+      btn.textContent = device.name;
+      btn.addEventListener('click', () => Homey.addDevice(device));
+      li.appendChild(btn);
+      listEl.appendChild(li);
+    });
+  } catch (err) {
+    Homey.alert(err.message || err.toString());
+  }
+});


### PR DESCRIPTION
## Summary
- use TuyAPI discovery results during pairing with new session handler
- add pairing UI to search for Adlar Heat Pumps and select a device

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e43df1088330abe9a04c3aa438af