### PR TITLE
Add pair sequence for Adlar Heat Pump driver

### DIFF
--- a/drivers/adlar_heat_pump/driver.compose.json
+++ b/drivers/adlar_heat_pump/driver.compose.json
@@ -18,5 +18,14 @@
     "measure_current",
     "measure_voltage",
     "measure_power"
+  ],
+  "pair": [
+    {
+      "id": "start",
+      "template": "view",
+      "options": {
+        "path": "start.html"
+      }
+    }
   ]
 }

--- a/drivers/adlar_heat_pump/driver.json
+++ b/drivers/adlar_heat_pump/driver.json
@@ -14,5 +14,14 @@
     "measure_current",
     "measure_voltage",
     "measure_power"
+  ],
+  "pair": [
+    {
+      "id": "start",
+      "template": "view",
+      "options": {
+        "path": "start.html"
+      }
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- declare a pairing view for the Adlar Heat Pump driver so devices can be discovered and added during pairing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b6975fc07c8330b0307b29cbdde3ce