### PR TITLE
Improve heat pump discovery diagnostics

### DIFF
--- a/drivers/adlar_heat_pump/device.js
+++ b/drivers/adlar_heat_pump/device.js
@@ -13,6 +13,7 @@ class AdlarHeatPumpDevice extends Device {
     try {
       await this.tuya.connect();
       this.setAvailable();
+      this.log('Connected to device', id);
       this.pollInterval = setInterval(() => this.updateStatus(), 10000);
     } catch (error) {
       this.error(error);
@@ -21,6 +22,7 @@ class AdlarHeatPumpDevice extends Device {
   }
 
   async updateStatus() {
+    this.log('Updating status');
     try {
       const tempIn = await this.tuya.get({ dps: 3 });
       this.setCapabilityValue('measure_temperature', Number(tempIn));
@@ -38,20 +40,24 @@ class AdlarHeatPumpDevice extends Device {
       this.setCapabilityValue('measure_power', Number(power) * 0.1);
       const target = await this.tuya.get({ dps: 2 });
       this.setCapabilityValue('target_temperature', Number(target));
+      this.log('Status update completed');
     } catch (error) {
       this.error('Status update failed', error);
     }
   }
 
   async onCapabilityOnoff(value) {
+    this.log('Set onoff to', value);
     await this.tuya.set({ dps: 1, set: value });
   }
 
   async onCapabilityTarget_temperature(value) {
+    this.log('Set target temperature to', value);
     await this.tuya.set({ dps: 2, set: value });
   }
 
   async onDeleted() {
+    this.log('Device deleted, cleaning up');
     clearInterval(this.pollInterval);
     await this.tuya.disconnect();
   }

--- a/drivers/adlar_heat_pump/driver.js
+++ b/drivers/adlar_heat_pump/driver.js
@@ -10,21 +10,31 @@ class AdlarHeatPumpDriver extends Driver {
   }
 
   async _discoverAndMerge() {
-    const found = await discoverDevices();
+    this.log('Starting discovery of Adlar Heat Pumps');
+    let found = [];
+    try {
+      found = await discoverDevices();
+      this.log('Local discovery finished', found);
+    } catch (error) {
+      this.log('Local discovery failed', error);
+    }
+
     let cloud = [];
     const username = process.env.TUYA_USERNAME;
     const password = process.env.TUYA_PASSWORD;
     const region = process.env.TUYA_REGION || 'EU';
 
     if (username && password) {
+      this.log('Attempting Tuya cloud lookup');
       try {
         cloud = await getCloudDeviceKeys({ username, password, region });
+        this.log('Tuya cloud lookup returned', cloud);
       } catch (error) {
         this.log('Tuya cloud lookup failed', error);
       }
     }
 
-    return found.map(dev => {
+    const merged = found.map(dev => {
       const info = cloud.find(c => c.id === dev.id) || {};
       return {
         name: `Adlar Heat Pump ${dev.id}`,
@@ -32,14 +42,19 @@ class AdlarHeatPumpDriver extends Driver {
         settings: { ip: dev.ip, key: info.key || '' }
       };
     });
+    this.log('Discovery result', merged);
+    return merged;
   }
 
   async onPairListDevices() {
+    this.log('onPairListDevices called');
     return this._discoverAndMerge();
   }
 
   async onPair(session) {
+    this.log('Pairing session started');
     session.setHandler('discover', async () => {
+      this.log('Pair discover handler invoked');
       return this._discoverAndMerge();
     });
   }

--- a/drivers/adlar_heat_pump/pair/start.js
+++ b/drivers/adlar_heat_pump/pair/start.js
@@ -1,11 +1,15 @@
 Homey.on('init', async () => {
+  console.log('[Pair] init');
   const listEl = document.getElementById('devices');
   try {
+    console.log('[Pair] requesting discovery');
     const devices = await Homey.emit('discover');
+    console.log('[Pair] discovery result', devices);
     if (devices.length === 0) {
       const li = document.createElement('li');
       li.textContent = 'No devices found';
       listEl.appendChild(li);
+      Homey.ready();
       return;
     }
     devices.forEach(device => {
@@ -16,7 +20,10 @@ Homey.on('init', async () => {
       li.appendChild(btn);
       listEl.appendChild(li);
     });
+    Homey.ready();
   } catch (err) {
+    console.error('[Pair] discovery error', err);
     Homey.alert(err.message || err.toString());
+    Homey.ready();
   }
 });

--- a/lib/tuyacloud.js
+++ b/lib/tuyacloud.js
@@ -12,6 +12,7 @@ const Cloud = require('@tuyapi/cloud');
  * @returns {Promise<Array<{id: string, key: string}>>}
  */
 async function getCloudDeviceKeys({ username, password, region = 'EU' }) {
+  console.log('[TuyaCloud] Fetching device keys', { username, region });
   const key = process.env.TUYA_API_KEY;
   const secret = process.env.TUYA_API_SECRET;
 
@@ -29,6 +30,7 @@ async function getCloudDeviceKeys({ username, password, region = 'EU' }) {
     const list = await api.request({ action: 'tuya.m.my.group.device.list', gid: group.groupId });
     devices = devices.concat(list.map(d => ({ id: d.devId, key: d.localKey })));
   }
+  console.log('[TuyaCloud] Retrieved device keys', devices);
   return devices;
 }
 

--- a/lib/tuyalocal.js
+++ b/lib/tuyalocal.js
@@ -3,39 +3,50 @@
 const TuyAPI = require('tuyapi');
 
 async function discoverDevices(timeout = 5000) {
-  const tuya = new TuyAPI({ id: '', key: '' });
+  console.log('[TuyaLocal] Starting device discovery');
+  const tuya = new TuyAPI({});
   try {
     const devices = await tuya.find({ timeout: Math.ceil(timeout / 1000), all: true });
+    console.log('[TuyaLocal] Discovery successful', devices);
     return devices.map(d => ({ id: d.id, ip: d.ip }));
   } catch (error) {
+    console.error('[TuyaLocal] Discovery failed', error);
     return [];
   }
 }
 
 class TuyaLocalDevice {
   constructor({ id, key, ip }) {
+    console.log('[TuyaLocal] Creating device', { id, ip });
     this.device = new TuyAPI({ id, key, ip });
   }
 
   async connect() {
+    console.log('[TuyaLocal] Connecting');
     await this.device.find();
     await this.device.connect();
+    console.log('[TuyaLocal] Connected');
   }
 
   async disconnect() {
     try {
+      console.log('[TuyaLocal] Disconnecting');
       await this.device.disconnect();
     } catch (error) {
-      // ignore
+      console.error('[TuyaLocal] Disconnect error', error);
     }
   }
 
   async set({ dps, set }) {
+    console.log('[TuyaLocal] Set', { dps, set });
     return this.device.set({ dps, set });
   }
 
   async get({ dps }) {
-    return this.device.get({ dps });
+    console.log('[TuyaLocal] Get', { dps });
+    const res = await this.device.get({ dps });
+    console.log('[TuyaLocal] Got', { dps, res });
+    return res;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add comprehensive logging around device discovery and Tuya communication
- Ensure pairing view calls `Homey.ready()` and logs discovery steps

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b69b9872f88330a535015752228998