### PR TITLE
Fix pairing discovery session

### DIFF
--- a/drivers/adlar_heat_pump/driver.js
+++ b/drivers/adlar_heat_pump/driver.js
@@ -53,10 +53,6 @@ class AdlarHeatPumpDriver extends Driver {
 
   async onPair(session) {
     this.log('Pairing session started');
-    session.setHandler('discover', async () => {
-      this.log('Pair discover handler invoked');
-      return this._discoverAndMerge();
-    });
   }
 }
 

--- a/drivers/adlar_heat_pump/pair/start.js
+++ b/drivers/adlar_heat_pump/pair/start.js
@@ -2,9 +2,9 @@ Homey.on('init', async () => {
   console.log('[Pair] init');
   const listEl = document.getElementById('devices');
   try {
-    console.log('[Pair] requesting discovery');
-    const devices = await Homey.emit('discover');
-    console.log('[Pair] discovery result', devices);
+    console.log('[Pair] requesting device list');
+    const devices = await Homey.emit('list_devices');
+    console.log('[Pair] device list result', devices);
     if (devices.length === 0) {
       const li = document.createElement('li');
       li.textContent = 'No devices found';


### PR DESCRIPTION
## Summary
- Use Homey's built-in `list_devices` event during pairing
- Simplify driver pairing hook

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b69e663a988330b7754fbecce8847f