### PR TITLE
Add Tuya credential pairing step

### DIFF
--- a/drivers/adlar_heat_pump/driver.js
+++ b/drivers/adlar_heat_pump/driver.js
@@ -9,7 +9,7 @@ class AdlarHeatPumpDriver extends Driver {
     this.log('Adlar Heat Pump driver has been initialized');
   }
 
-  async _discoverAndMerge() {
+  async _discoverAndMerge(creds = {}) {
     this.log('Starting discovery of Adlar Heat Pumps');
     let found = [];
     try {
@@ -20,9 +20,9 @@ class AdlarHeatPumpDriver extends Driver {
     }
 
     let cloud = [];
-    const username = process.env.TUYA_USERNAME;
-    const password = process.env.TUYA_PASSWORD;
-    const region = process.env.TUYA_REGION || 'EU';
+    const username = creds.username || process.env.TUYA_USERNAME;
+    const password = creds.password || process.env.TUYA_PASSWORD;
+    const region = creds.region || process.env.TUYA_REGION || 'EU';
 
     if (username && password) {
       this.log('Attempting Tuya cloud lookup');
@@ -53,6 +53,16 @@ class AdlarHeatPumpDriver extends Driver {
 
   async onPair(session) {
     this.log('Pairing session started');
+    let creds = {};
+
+    session.setHandler('login', async data => {
+      creds = data || {};
+      return true;
+    });
+
+    session.setHandler('list_devices', async () => {
+      return this._discoverAndMerge(creds);
+    });
   }
 }
 

--- a/drivers/adlar_heat_pump/pair/start.html
+++ b/drivers/adlar_heat_pump/pair/start.html
@@ -5,7 +5,19 @@
     <script src="/homey.js" data-origin="local"></script>
   </head>
   <body>
-    <p>Searching for Adlar Heat Pumps...</p>
+    <form id="login">
+      <p>Tuya Cloud Credentials (optional):</p>
+      <input type="text" id="username" placeholder="Username" />
+      <input type="password" id="password" placeholder="Password" />
+      <label for="region">Region:</label>
+      <select id="region">
+        <option value="EU">EU</option>
+        <option value="AZ">AZ</option>
+        <option value="AY">AY</option>
+        <option value="IN">IN</option>
+      </select>
+      <button type="submit">Discover Devices</button>
+    </form>
     <ul id="devices"></ul>
     <script src="start.js"></script>
   </body>

--- a/drivers/adlar_heat_pump/pair/start.js
+++ b/drivers/adlar_heat_pump/pair/start.js
@@ -1,29 +1,38 @@
-Homey.on('init', async () => {
+Homey.on('init', () => {
   console.log('[Pair] init');
+  const form = document.getElementById('login');
   const listEl = document.getElementById('devices');
-  try {
-    console.log('[Pair] requesting device list');
-    const devices = await Homey.emit('list_devices');
-    console.log('[Pair] device list result', devices);
-    if (devices.length === 0) {
-      const li = document.createElement('li');
-      li.textContent = 'No devices found';
-      listEl.appendChild(li);
-      Homey.ready();
-      return;
+
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    listEl.innerHTML = '';
+    const username = document.getElementById('username').value;
+    const password = document.getElementById('password').value;
+    const region = document.getElementById('region').value;
+    try {
+      await Homey.emit('login', { username, password, region });
+      console.log('[Pair] requesting device list');
+      const devices = await Homey.emit('list_devices');
+      console.log('[Pair] device list result', devices);
+      if (devices.length === 0) {
+        const li = document.createElement('li');
+        li.textContent = 'No devices found';
+        listEl.appendChild(li);
+        return;
+      }
+      devices.forEach(device => {
+        const li = document.createElement('li');
+        const btn = document.createElement('button');
+        btn.textContent = device.name;
+        btn.addEventListener('click', () => Homey.addDevice(device));
+        li.appendChild(btn);
+        listEl.appendChild(li);
+      });
+    } catch (err) {
+      console.error('[Pair] discovery error', err);
+      Homey.alert(err.message || err.toString());
     }
-    devices.forEach(device => {
-      const li = document.createElement('li');
-      const btn = document.createElement('button');
-      btn.textContent = device.name;
-      btn.addEventListener('click', () => Homey.addDevice(device));
-      li.appendChild(btn);
-      listEl.appendChild(li);
-    });
-    Homey.ready();
-  } catch (err) {
-    console.error('[Pair] discovery error', err);
-    Homey.alert(err.message || err.toString());
-    Homey.ready();
-  }
+  });
+
+  Homey.ready();
 });


### PR DESCRIPTION
## Summary
- allow entering Tuya cloud credentials during pairing
- respond to pairing events to discover devices with provided credentials

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a136d8108330bfa3e93eeb2557fe