### PR TITLE
Fix Homey script path in pairing UI

### DIFF
--- a/drivers/adlar_heat_pump/pair/start.html
+++ b/drivers/adlar_heat_pump/pair/start.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8"/>
-    <script src="/homey.js" data-origin="local"></script>
+    <script src="/homey.js"></script>
   </head>
   <body>
     <form id="login">


### PR DESCRIPTION
## Summary
- fix pairing error by removing `data-origin="local"` so Homey's script loads correctly

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a3506b308330bdc3efd7235651a4