### PR TITLE
Fix pairing credentials form resetting

### DIFF
--- a/drivers/adlar_heat_pump/pair/start.html
+++ b/drivers/adlar_heat_pump/pair/start.html
@@ -5,7 +5,7 @@
     <script src="/homey.js"></script>
   </head>
   <body>
-    <form id="login">
+    <form id="credentials">
       <p>Tuya Cloud Credentials (optional):</p>
       <input type="text" id="username" placeholder="Username" />
       <input type="password" id="password" placeholder="Password" />

--- a/drivers/adlar_heat_pump/pair/start.js
+++ b/drivers/adlar_heat_pump/pair/start.js
@@ -1,6 +1,6 @@
 Homey.on('init', () => {
   console.log('[Pair] init');
-  const form = document.getElementById('login');
+  const form = document.getElementById('credentials');
   const listEl = document.getElementById('devices');
 
   form.addEventListener('submit', async e => {


### PR DESCRIPTION
## Summary
- avoid Homey auto-login handling by using unique credentials form id
- update pairing script to match new form id

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a65b9e408330a5bccac4e5943837