### PR TITLE
Handle Tuya cloud-only devices during discovery

### DIFF
--- a/drivers/adlar_heat_pump/driver.js
+++ b/drivers/adlar_heat_pump/driver.js
@@ -42,6 +42,18 @@ class AdlarHeatPumpDriver extends Driver {
         settings: { ip: dev.ip, key: info.key || '' }
       };
     });
+
+    const foundIds = new Set(found.map(dev => dev.id));
+    cloud.forEach(info => {
+      if (!foundIds.has(info.id)) {
+        merged.push({
+          name: `Adlar Heat Pump ${info.id}`,
+          data: { id: info.id },
+          settings: { ip: '', key: info.key || '' }
+        });
+      }
+    });
+
     this.log('Discovery result', merged);
     return merged;
   }


### PR DESCRIPTION
## Summary
- Include devices retrieved from Tuya Cloud in the pairing list even when no local device is found.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a81dc130833090b316d5ed8cf115