### PR TITLE
Fix pairing discovery and add extensive logging

### DIFF
--- a/drivers/adlar_heat_pump/driver.js
+++ b/drivers/adlar_heat_pump/driver.js
@@ -10,28 +10,31 @@ class AdlarHeatPumpDriver extends Driver {
   }
 
   async _discoverAndMerge(creds = {}) {
-    this.log('Starting discovery of Adlar Heat Pumps');
-    let found = [];
-    try {
-      found = await discoverDevices();
-      this.log('Local discovery finished', found);
-    } catch (error) {
-      this.log('Local discovery failed', error);
-    }
-
-    let cloud = [];
     const username = creds.username || process.env.TUYA_USERNAME;
     const password = creds.password || process.env.TUYA_PASSWORD;
     const region = creds.region || process.env.TUYA_REGION || 'EU';
+    this.log('Starting discovery of Adlar Heat Pumps', { hasUsername: !!username, region });
+
+    let found = [];
+    try {
+      found = await discoverDevices();
+      this.log('Local discovery finished', { count: found.length, devices: found });
+    } catch (error) {
+      this.error('Local discovery failed', error);
+    }
+
+    let cloud = [];
 
     if (username && password) {
-      this.log('Attempting Tuya cloud lookup');
+      this.log('Attempting Tuya cloud lookup', { username, region });
       try {
         cloud = await getCloudDeviceKeys({ username, password, region });
-        this.log('Tuya cloud lookup returned', cloud);
+        this.log('Tuya cloud lookup returned', { count: cloud.length, devices: cloud });
       } catch (error) {
-        this.log('Tuya cloud lookup failed', error);
+        this.error('Tuya cloud lookup failed', error);
       }
+    } else {
+      this.log('No Tuya cloud credentials provided, skipping cloud lookup');
     }
 
     const merged = found.map(dev => {
@@ -54,7 +57,7 @@ class AdlarHeatPumpDriver extends Driver {
       }
     });
 
-    this.log('Discovery result', merged);
+    this.log('Discovery result', { count: merged.length, devices: merged });
     return merged;
   }
 
@@ -68,11 +71,13 @@ class AdlarHeatPumpDriver extends Driver {
     let creds = {};
 
     session.setHandler('login', async data => {
+      this.log('Login handler invoked', { hasUsername: !!data.username, region: data.region });
       creds = data || {};
       return true;
     });
 
     session.setHandler('list_devices', async () => {
+      this.log('List devices handler invoked');
       return this._discoverAndMerge(creds);
     });
   }

--- a/drivers/adlar_heat_pump/pair/start.html
+++ b/drivers/adlar_heat_pump/pair/start.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8"/>
 </head>
 <body>
-  <div class="homey-form">
+  <form id="credentials" class="homey-form">
     <h2>Tuya Cloud Credentials (optional)</h2>
 
     <label for="username">Username</label>
@@ -22,7 +22,8 @@
       <option value="IN">IN</option>
     </select>
 
-    <button id="submit">Discover Devices</button>
-  </div>
+    <button id="submit" type="submit">Discover Devices</button>
+  </form>
+  <ul id="devices"></ul>
 </body>
 </html>

--- a/drivers/adlar_heat_pump/pair/start.js
+++ b/drivers/adlar_heat_pump/pair/start.js
@@ -3,14 +3,27 @@ Homey.on('init', () => {
   const form = document.getElementById('credentials');
   const listEl = document.getElementById('devices');
 
+  if (!form) {
+    console.error('[Pair] credentials form not found');
+    Homey.ready();
+    return;
+  }
+  if (!listEl) {
+    console.error('[Pair] device list element not found');
+    Homey.ready();
+    return;
+  }
+
   form.addEventListener('submit', async e => {
     e.preventDefault();
     listEl.innerHTML = '';
     const username = document.getElementById('username').value;
     const password = document.getElementById('password').value;
     const region = document.getElementById('region').value;
+    console.log('[Pair] submitting credentials', { username, region });
     try {
       await Homey.emit('login', { username, password, region });
+      console.log('[Pair] login successful');
       console.log('[Pair] requesting device list');
       const devices = await Homey.emit('list_devices');
       console.log('[Pair] device list result', devices);

--- a/lib/tuyacloud.js
+++ b/lib/tuyacloud.js
@@ -22,12 +22,19 @@ async function getCloudDeviceKeys({ username, password, region = 'EU' }) {
 
   const api = new Cloud({ key, secret, region });
 
+  console.log('[TuyaCloud] Logging in');
   await api.loginEx({ email: username, password });
+  console.log('[TuyaCloud] Login successful');
 
+  console.log('[TuyaCloud] Requesting location list');
   const groups = await api.request({ action: 'tuya.m.location.list' });
+  console.log('[TuyaCloud] Location list response', groups);
+
   let devices = [];
   for (const group of groups) {
+    console.log('[TuyaCloud] Requesting device list for group', group.groupId);
     const list = await api.request({ action: 'tuya.m.my.group.device.list', gid: group.groupId });
+    console.log('[TuyaCloud] Device list for group', group.groupId, list);
     devices = devices.concat(list.map(d => ({ id: d.devId, key: d.localKey })));
   }
   console.log('[TuyaCloud] Retrieved device keys', devices);

--- a/lib/tuyalocal.js
+++ b/lib/tuyalocal.js
@@ -3,11 +3,11 @@
 const TuyAPI = require('tuyapi');
 
 async function discoverDevices(timeout = 5000) {
-  console.log('[TuyaLocal] Starting device discovery');
+  console.log('[TuyaLocal] Starting device discovery', { timeout });
   const tuya = new TuyAPI({});
   try {
     const devices = await tuya.find({ timeout: Math.ceil(timeout / 1000), all: true });
-    console.log('[TuyaLocal] Discovery successful', devices);
+    console.log('[TuyaLocal] Discovery successful', { count: devices.length, devices });
     return devices.map(d => ({ id: d.id, ip: d.ip }));
   } catch (error) {
     console.error('[TuyaLocal] Discovery failed', error);


### PR DESCRIPTION
## Summary
- fix pairing UI by wiring button through a credentials form and device list container
- add detailed logging for pairing workflow, local discovery, and Tuya Cloud communication

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b46bae64833080b81d8950e1df48