### PR TITLE
Handle missing Tuya IP

### DIFF
--- a/lib/tuya-device-wrapper.js
+++ b/lib/tuya-device-wrapper.js
@@ -34,13 +34,23 @@ export default class TuyaDeviceWrapper {
       } catch (e) {
         this.error('Kon IP niet vinden:', e?.message || e);
       }
+
+      if (!this.device.ip) {
+        throw new Error('IP niet gevonden, verbinding niet mogelijk');
+      }
     }
 
-    this.log('Maak verbinding...');
-    await this.device.connect();
     this.device.on('connected', () => this.log('TUYA connected'));
     this.device.on('disconnected', () => this.log('TUYA disconnected'));
     this.device.on('error', (err) => this.error('TUYA error', err?.message || err));
+
+    this.log('Maak verbinding...');
+    try {
+      await this.device.connect();
+    } catch (e) {
+      this.error('Socket connect faalde:', e?.message || e);
+      throw e;
+    }
 
     // Probeer eerste status op te halen
     try {


### PR DESCRIPTION
## Summary
- guard against missing Tuya device IP, aborting connection if discovery fails
- register TuyAPI event listeners before connecting and catch socket failures

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b84c9b5c288330b6c865a3e1590313