### PR TITLE
Add network device discovery button in settings

### DIFF
--- a/settings/index.html
+++ b/settings/index.html
@@ -26,6 +26,7 @@
     <section>
       <button id="btnSave">Opslaan</button>
       <button id="btnTest">Test lokale verbinding</button>
+      <button id="btnSearch">Zoek alle apparaten</button>
     </section>
 
     <section>

--- a/settings/index.js
+++ b/settings/index.js
@@ -2,12 +2,14 @@
 
 async function load(Homey) {
   // Populate fields
-  for (const key of ['tuya_access_id', 'tuya_access_key', 'tuya_device_id', 'tuya_local_key', 'tuya_last_test_log']) {
+  for (const key of ['tuya_access_id', 'tuya_access_key', 'tuya_device_id', 'tuya_local_key', 'tuya_last_test_log', 'tuya_last_discover_log']) {
     try {
       const val = await Homey.get(key);
       const el = document.getElementById(key);
       if (el && typeof val === 'string') el.value = val;
-      if (key === 'tuya_last_test_log' && val) document.getElementById('log').textContent = val;
+      if ((key === 'tuya_last_test_log' || key === 'tuya_last_discover_log') && val) {
+        document.getElementById('log').textContent = val;
+      }
     } catch (e) {
       // ignore
     }
@@ -30,6 +32,23 @@ async function load(Homey) {
     const poll = setInterval(async () => {
       const log = await Homey.get('tuya_last_test_log');
       if (log && log.includes('Test klaar')) {
+        clearInterval(poll);
+        document.getElementById('log').textContent = log;
+      } else if (Date.now() - start > 10000) {
+        clearInterval(poll);
+        document.getElementById('log').textContent = 'Time-out: geen resultaat binnen 10s.';
+      }
+    }, 800);
+  });
+
+  document.getElementById('btnSearch').addEventListener('click', async () => {
+    document.getElementById('log').textContent = 'Zoeken gestart... even geduld';
+    await Homey.set('tuya_last_discover_log', '');
+    await Homey.set('tuya_find_now', true);
+    const start = Date.now();
+    const poll = setInterval(async () => {
+      const log = await Homey.get('tuya_last_discover_log');
+      if (log && log.includes('Zoeken klaar')) {
         clearInterval(poll);
         document.getElementById('log').textContent = log;
       } else if (Date.now() - start > 10000) {


### PR DESCRIPTION
## Summary
- add "Zoek alle apparaten" button to settings UI
- wire button to new Homey settings handler to discover Tuya devices on LAN

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b84e79564883308d808f9f02d17cb0