### PR TITLE
Fix Tuya discovery listening ports and add debug logging

### DIFF
--- a/lib/tuya-client.js
+++ b/lib/tuya-client.js
@@ -31,9 +31,12 @@ export default class TuyaClient {
   /**
    * Lightweight LAN discovery. We attempt two strategies:
    * 1) Listen for UDP broadcasts on ports 6666/6667 for a short time.
-   * 2) (Optional) Future: use tuyapi.find() if available for active scanning.
+  * 2) (Optional) Future: use tuyapi.find() if available for active scanning.
    */
   async findNearbyDevices({ timeoutMs = 5000 } = {}) {
+    const log = (...a) => this.app.log('[DISCOVER]', ...a);
+    log(`Starting discovery for ${timeoutMs} ms`);
+
     const devices = new Map();
 
     const parseAndAdd = (buf) => {
@@ -45,24 +48,37 @@ export default class TuyaClient {
         if (gwMatch) {
           const gwId = gwMatch[1];
           const productKey = pkMatch ? pkMatch[1] : null;
-          if (!devices.has(gwId)) devices.set(gwId, { gwId, productKey });
+          if (!devices.has(gwId)) {
+            devices.set(gwId, { gwId, productKey });
+            log(`Discovered ${gwId}${productKey ? ' (' + productKey + ')' : ''}`);
+          }
+        } else {
+          log('Received UDP packet without gwId');
         }
-      } catch (_) {}
+      } catch (e) {
+        log(`Error parsing UDP packet: ${e?.message || e}`);
+      }
     };
 
-    const sockets = [6666, 6667].map(port => dgram.createSocket('udp4'));
-    await Promise.all(sockets.map(sock => new Promise((resolve) => {
-      sock.on('message', (msg) => parseAndAdd(msg));
-      // Bind on random port and try to connect to avoid permission issues
-      sock.bind(0, () => {
+    const ports = [6666, 6667];
+    const sockets = await Promise.all(ports.map(port => new Promise((resolve) => {
+      const sock = dgram.createSocket('udp4');
+      sock.on('message', (msg, rinfo) => {
+        log(`UDP from ${rinfo.address}:${rinfo.port} -> ${port} (${msg.length} bytes)`);
+        parseAndAdd(msg);
+      });
+      sock.bind(port, () => {
+        log(`Listening on UDP port ${port}`);
         try { sock.addMembership('224.0.0.0'); } catch (_) {}
-        resolve();
+        resolve(sock);
       });
     })));
 
     await new Promise(res => setTimeout(res, timeoutMs));
 
     sockets.forEach(s => { try { s.close(); } catch (_) {} });
+
+    log(`Discovery finished, found ${devices.size} device(s)`);
 
     // Convert to array
     return Array.from(devices.values());


### PR DESCRIPTION
## Summary
- listen on UDP ports 6666/6667 instead of random port
- add detailed discovery logging for easier troubleshooting

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8512a867483309a949640e098d079