### PR TITLE
feat: add optional local IP setting

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+
 import Homey from 'homey';
 import TuyaClient from './lib/tuya-client.js';
 
@@ -30,15 +31,16 @@ class AdlarApp extends Homey.App {
       const accKey = settings.get('tuya_access_key');
       const defaultDeviceId = settings.get('tuya_device_id');
       const defaultLocalKey = settings.get('tuya_local_key');
+      const defaultIp = settings.get('tuya_local_ip');
 
       const start = new Date();
       log(`[${start.toISOString()}] Test gestart`);
-      log(`Access ID present: ${Boolean(accId)} | Device ID: ${defaultDeviceId || '(leeg)'} `);
+      log(`Access ID present: ${Boolean(accId)} | Device ID: ${defaultDeviceId || '(leeg)'} | IP: ${defaultIp || '(leeg)'}`);
 
       try {
         if (defaultDeviceId && defaultLocalKey) {
           log('Probeer lokale Tuya-verbinding (LAN)...');
-          const res = await this.tuya.testLocalConnection({ deviceId: defaultDeviceId, localKey: defaultLocalKey });
+          const res = await this.tuya.testLocalConnection({ deviceId: defaultDeviceId, localKey: defaultLocalKey, ip: defaultIp });
           log(`LAN test: ${res.ok ? 'SUCCES' : 'MISLUKT'}${res.detail ? ' — ' + res.detail : ''}`);
         } else {
           log('Geen Device ID / Local Key ingevuld — sla lokale test over.');

--- a/lib/tuya-client.js
+++ b/lib/tuya-client.js
@@ -9,18 +9,19 @@ export default class TuyaClient {
    * Try to connect locally to a known device using its Device ID & Local Key.
    * Uses the TuyaDeviceWrapper (tuyapi under the hood).
    */
-  async testLocalConnection({ deviceId, localKey }) {
+  async testLocalConnection({ deviceId, localKey, ip = null }) {
     const { default: TuyaDeviceWrapper } = await import('./tuya-device-wrapper.js');
     const tdw = new TuyaDeviceWrapper({
       homey: this.app.homey,
       deviceId,
       localKey,
+      ip: ip || undefined,
       log: (...a) => this.app.log('[TEST]', ...a),
       error: (...a) => this.app.error('[TEST]', ...a),
     });
 
     try {
-      await tdw.connect({ findIP: true, timeoutMs: 5000 });
+      await tdw.connect({ findIP: !ip, timeoutMs: 5000 });
       await tdw.disconnect();
       return { ok: true, detail: 'LAN reachable' };
     } catch (e) {

--- a/settings/index.html
+++ b/settings/index.html
@@ -21,6 +21,7 @@
       <h2>Standaard lokaal device</h2>
       <label>Device ID <input id="tuya_device_id" placeholder="bfc9c6d6ded27c80a3im4n"></label>
       <label>Local Key <input id="tuya_local_key" placeholder="xxxxxxxxxxxxxxxx"></label>
+      <label>Local IP (optioneel) <input id="tuya_local_ip" placeholder="192.168.1.100"></label>
     </section>
 
     <section>

--- a/settings/index.js
+++ b/settings/index.js
@@ -2,7 +2,7 @@
 
 async function load(Homey) {
   // Populate fields
-  for (const key of ['tuya_access_id', 'tuya_access_key', 'tuya_device_id', 'tuya_local_key', 'tuya_last_test_log', 'tuya_last_discover_log']) {
+  for (const key of ['tuya_access_id', 'tuya_access_key', 'tuya_device_id', 'tuya_local_key', 'tuya_local_ip', 'tuya_last_test_log', 'tuya_last_discover_log']) {
     try {
       const val = await Homey.get(key);
       const el = document.getElementById(key);
@@ -16,7 +16,7 @@ async function load(Homey) {
   }
 
   document.getElementById('btnSave').addEventListener('click', async () => {
-    for (const key of ['tuya_access_id', 'tuya_access_key', 'tuya_device_id', 'tuya_local_key']) {
+    for (const key of ['tuya_access_id', 'tuya_access_key', 'tuya_device_id', 'tuya_local_key', 'tuya_local_ip']) {
       const el = document.getElementById(key);
       await Homey.set(key, el.value || '');
     }


### PR DESCRIPTION
## Summary
- allow entering optional local IP address in settings
- wire local IP into Tuya test connection logic

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b859a3a99883308c2096676172128a