### PR TITLE
Improve Tuya discovery using latest TuyAPI

### DIFF
--- a/lib/tuya-client.js
+++ b/lib/tuya-client.js
@@ -1,4 +1,6 @@
 import dgram from 'dgram';
+import {MessageParser} from 'tuyapi/lib/message-parser.js';
+import {UDP_KEY} from 'tuyapi/lib/config.js';
 
 export default class TuyaClient {
   constructor({ app }) {
@@ -40,21 +42,22 @@ export default class TuyaClient {
 
     const devices = new Map();
 
-    const parseAndAdd = (buf) => {
+    const udpParser = new MessageParser({key: UDP_KEY});
+
+    const parseAndAdd = (buf, rinfo) => {
       try {
-        const s = buf.toString();
-        // Tuya broadcast frames often contain JSON-like substrings with gwId and productKey
-        const gwMatch = s.match(/"gwId"\s*:\s*"([^"]+)"/);
-        const pkMatch = s.match(/"productKey"\s*:\s*"([^"]+)"/);
-        if (gwMatch) {
-          const gwId = gwMatch[1];
-          const productKey = pkMatch ? pkMatch[1] : null;
-          if (!devices.has(gwId)) {
-            devices.set(gwId, { gwId, productKey });
-            log(`Discovered ${gwId}${productKey ? ' (' + productKey + ')' : ''}`);
+        const packets = udpParser.parse(buf);
+        for (const p of packets) {
+          const gwId = p?.payload?.gwId;
+          const productKey = p?.payload?.productKey;
+          if (gwId) {
+            if (!devices.has(gwId)) {
+              devices.set(gwId, { gwId, productKey, ip: rinfo?.address });
+              log(`Discovered ${gwId}${productKey ? ' (' + productKey + ')' : ''}`);
+            }
+          } else {
+            log('Received UDP packet without gwId');
           }
-        } else {
-          log('Received UDP packet without gwId');
         }
       } catch (e) {
         log(`Error parsing UDP packet: ${e?.message || e}`);
@@ -66,7 +69,7 @@ export default class TuyaClient {
       const sock = dgram.createSocket('udp4');
       sock.on('message', (msg, rinfo) => {
         log(`UDP from ${rinfo.address}:${rinfo.port} -> ${port} (${msg.length} bytes)`);
-        parseAndAdd(msg);
+        parseAndAdd(msg, rinfo);
       });
       sock.bind(port, () => {
         log(`Listening on UDP port ${port}`);
@@ -78,6 +81,25 @@ export default class TuyaClient {
     await new Promise(res => setTimeout(res, timeoutMs));
 
     sockets.forEach(s => { try { s.close(); } catch (_) {} });
+
+    if (devices.size === 0) {
+      try {
+        const {default: TuyAPI} = await import('tuyapi');
+        const finder = new TuyAPI({});
+        const found = await finder.find({all: true, timeout: Math.ceil(timeoutMs / 1000)});
+        if (Array.isArray(found)) {
+          for (const d of found) {
+            const gwId = d.id;
+            if (gwId && !devices.has(gwId)) {
+              devices.set(gwId, {gwId, productKey: null, ip: d.ip});
+              log(`Discovered ${gwId} via active scan`);
+            }
+          }
+        }
+      } catch (e) {
+        log(`tuyapi.find() error: ${e?.message || e}`);
+      }
+    }
 
     log(`Discovery finished, found ${devices.size} device(s)`);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "tuyapi": "^7.6.1"
+        "tuyapi": "^7.7.1"
       }
     },
     "node_modules/@types/retry": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     "postinstall": "echo \"Note: install dev deps if needed.\""
   },
   "dependencies": {
-    "tuyapi": "^7.6.1"
+    "tuyapi": "^7.7.1"
   }
 }


### PR DESCRIPTION
## Summary
- parse UDP discovery packets with TuyAPI's MessageParser and UDP key
- fall back to active scanning via `tuyapi.find()`
- upgrade to TuyAPI 7.7.1

## Testing
- `npm install`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b87c83fdc08330a9e31fe86184bf24